### PR TITLE
Adding LCD drivers to trunk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 cmake_minimum_required(VERSION 3.13)
 
 set(NAME my_project) # <-- change as needed.
-set(PICO_BOARD pico CACHE STRING "Board type")
+set(PICO_BOARD pico2 CACHE STRING "Board type")
 
 # initialize the SDK based on PICO_SDK_PATH note: this must happen before
 # project()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 cmake_minimum_required(VERSION 3.13)
 
 set(NAME my_project) # <-- change as needed.
-set(PICO_BOARD pico2 CACHE STRING "Board type")
+set(PICO_BOARD pico CACHE STRING "Board type")
 
 # initialize the SDK based on PICO_SDK_PATH note: this must happen before
 # project()
@@ -74,6 +74,7 @@ add_subdirectory(./ap33772)
 add_subdirectory(./stusb4500)
 add_subdirectory(./ssd1306)
 add_subdirectory(./ush)
+add_subdirectory(./lcd/i2c_lcd)
 
 # Modify the below lines to enable/disable output over UART/USB
 pico_enable_stdio_uart(${NAME} 0)
@@ -87,6 +88,7 @@ target_link_libraries(${NAME}
     stusb4500 
     ssd1306 
     ush
+    i2c_lcd
 )
 
 # create map/bin/hex/uf2 file in addition to ELF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 cmake_minimum_required(VERSION 3.13)
 
 set(NAME my_project) # <-- change as needed.
-set(PICO_BOARD pico2 CACHE STRING "Board type")
+set(PICO_BOARD pico CACHE STRING "Board type")
 
 # initialize the SDK based on PICO_SDK_PATH note: this must happen before
 # project()
@@ -77,8 +77,8 @@ add_subdirectory(./ush)
 add_subdirectory(./lcd/i2c_lcd)
 
 # Modify the below lines to enable/disable output over UART/USB
-pico_enable_stdio_uart(${NAME} 0)
-pico_enable_stdio_usb(${NAME} 1)
+pico_enable_stdio_uart(${NAME} 1)
+pico_enable_stdio_usb(${NAME} 0)
 
 
 target_link_libraries(${NAME} 

--- a/lcd/HD44780.h
+++ b/lcd/HD44780.h
@@ -1,0 +1,39 @@
+/**
+ * @file HD44780.h
+ * @brief The following constatnt names were taken from the avrlib lcd.h header file.
+ */
+
+#define LCD_CLR (0x01)
+#define LCD_HOME (0x02)
+
+
+#define LCD_CLR  (0x01)              // DB0: clear display
+#define LCD_HOME  (0x02)             // DB1: return to home position
+
+#define LCD_ENTRY_MODE  (0x04)       // DB2: set entry mode
+#define LCD_ENTRY_INC  (0x02)        // --DB1: increment
+#define LCD_ENTRY_SHIFT  (0x01)      // --DB0: shift
+
+#define LCD_ON_CTRL  (0x08)          // DB3: turn lcd/cursor on
+#define LCD_ON_DISPLAY  (0x04)       // --DB2: turn display on
+#define LCD_ON_CURSOR  (0x02)        // --DB1: turn cursor on
+#define LCD_ON_BLINK  (0x01)         // --DB0: blinking cursor
+
+#define LCD_MOVE  (0x10)             // DB4: move cursor/display
+#define LCD_MOVE_DISP  (0x08)        // --DB3: move display (0-> move cursor)
+#define LCD_MOVE_RIGHT  (0x04)       // --DB2: move right (0-> left)
+
+#define LCD_FUNCTION  (0x20)         // DB5: function set
+#define LCD_FUNCTION_8BIT  (0x10)    // --DB4: set 8BIT mode (0->4BIT mode)
+#define LCD_FUNCTION_2LINES  (0x08)  // --DB3: two lines (0->one line)
+#define LCD_FUNCTION_10DOTS  (0x04)  // --DB2: 5x10 font (0->5x7 font)
+#define LCD_FUNCTION_RESET  (0x30)   // See "Initializing by Instruction" section
+
+#define LCD_CGRAM  (0x40)            // DB6: set CG RAM address
+#define LCD_DDRAM  (0x80)            // DB7: set DD RAM address
+
+#define LCD_RS_CMD (0)
+#define LCD_RS_DATA (1)
+
+#define LCD_RW_WRITE (0)
+#define LCD_RW_READ  (1)

--- a/lcd/i2c_lcd/CMakeLists.txt
+++ b/lcd/i2c_lcd/CMakeLists.txt
@@ -1,0 +1,1 @@
+include(i2c_lcd.cmake)

--- a/lcd/i2c_lcd/i2c_lcd.cmake
+++ b/lcd/i2c_lcd/i2c_lcd.cmake
@@ -1,0 +1,9 @@
+set(LIB_NAME i2c_lcd)
+add_library(${LIB_NAME} INTERFACE)
+
+target_sources(${LIB_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR}/${LIB_NAME}.cpp)
+
+target_include_directories(${LIB_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+# Pull in pico libraries that are needed
+target_link_libraries(${LIB_NAME} INTERFACE pico_stdlib i2c)

--- a/lcd/i2c_lcd/i2c_lcd.cpp
+++ b/lcd/i2c_lcd/i2c_lcd.cpp
@@ -1,0 +1,82 @@
+#include "i2c_lcd.hpp"
+
+
+I2CLCD::I2CLCD(I2C* i2c, uint8_t addr, uint8_t num_rows, uint8_t num_cols) :
+  i2c(i2c),
+  addr(addr),
+  num_rows(num_rows),
+  num_cols(num_cols),
+  cursor_x(0),
+  cursor_y(0),
+  nl_reached(false) {
+  i2c->write_blocking(addr, 0x00, 1, false);
+
+  uint32_t wait = millis();
+  while (millis() - wait < 20);
+
+  write_nibble(LCD_FUNCTION_RESET);
+
+  wait = millis();
+  while (millis() - wait < 5);
+
+  //NOTE: Not sure why this is necessary, but it is.
+  write_nibble(LCD_FUNCTION_RESET);
+  write_nibble(LCD_FUNCTION_RESET);
+  write_nibble(LCD_FUNCTION);
+
+  uint8_t cmd = LCD_FUNCTION;
+  num_rows > 1 ? cmd |= LCD_FUNCTION_2LINES : cmd = cmd;
+  write_command(cmd);
+}
+
+void I2CLCD::write_nibble(uint8_t nibble) {
+  uint8_t byte = ((nibble >> 4) & 0x0f) << SHIFT_DATA;
+  uint8_t b_mask = byte | MASK_E;
+  i2c->write_blocking(addr, &b_mask, 1, false);
+  i2c->write_blocking(addr, &byte, 1, false);
+  return;
+}
+
+void I2CLCD::write_command(uint8_t cmd) {
+  uint8_t b = ((is_backlight << SHIFT_BACKLIGHT) | (((cmd >> 4) & 0x0f) << SHIFT_DATA));
+  uint8_t b_mask = b | MASK_E;
+  i2c->write_blocking(addr, &b_mask, 1, false);
+  i2c->write_blocking(addr, &b, 1, false);
+
+  b = ((is_backlight << SHIFT_BACKLIGHT) | ((cmd & 0x0f) << SHIFT_DATA));
+  b_mask = b | MASK_E;
+  i2c->write_blocking(addr, &b_mask, 1, false);
+  i2c->write_blocking(addr, &b, 1, false);
+
+  //The home and clear commands require a worst case delay of 4.1 milliseconds.
+  if (cmd <= 3) {
+    uint32_t wait = millis();
+    while (millis() - wait < 5);
+  }
+}
+
+void I2CLCD::write_data(uint8_t data) {
+  uint8_t b = (MASK_RS | (is_backlight << SHIFT_BACKLIGHT) | (((data >> 4) & 0x0f) << SHIFT_DATA));
+  uint8_t b_mask = b | MASK_E;
+  i2c->write_blocking(addr, &b_mask, 1, false);
+  i2c->write_blocking(addr, &b, 1, false);
+
+  b = (MASK_RS | (is_backlight << SHIFT_BACKLIGHT) | ((data & 0x0f) << SHIFT_DATA));
+  b_mask = b | MASK_E;
+  i2c->write_blocking(addr, &b_mask, 1, false);
+  i2c->write_blocking(addr, &b, 1, false);
+  return;
+}
+
+void I2CLCD::backlight(bool on) {
+  if (on) {
+    uint8_t b = 1 << SHIFT_BACKLIGHT;
+    i2c->write_blocking(addr, &b, 1, false);
+    is_backlight = true;
+    return;
+  }
+  i2c->write_blocking(addr, 0x00, 1, false);
+  is_backlight = false;
+  return;
+}
+

--- a/lcd/i2c_lcd/i2c_lcd.cpp
+++ b/lcd/i2c_lcd/i2c_lcd.cpp
@@ -1,22 +1,21 @@
 #include "i2c_lcd.hpp"
-#include <cstdio>
 
 #define SLEEP_TIME_MS (5)
 
+/*#define LCD_PRINT_DEBUG*/
 
-I2CLCD::I2CLCD(uint8_t num_rows, uint8_t num_cols) : LCD(num_rows, num_cols)
-{
-  I2C i2c = I2C();
-  is_backlight = true;
 
+I2CLCD::I2CLCD(uint8_t num_rows, uint8_t num_cols) : LCD(num_rows, num_cols), i2c(I2C()), is_backlight(true) {
   i2c.write_blocking(LCD_I2C_ADDRESS, 0x00, 1, false);
-
-  //NOTE: Not sure why this is necessary, but it is.
   write_nibble(LCD_FUNCTION_RESET);
-  write_nibble(LCD_FUNCTION_RESET);
-  write_nibble(LCD_FUNCTION_RESET);
-
   write_nibble(LCD_FUNCTION);
+  display_off();
+  clear();
+
+  write_command(LCD_ENTRY_MODE | LCD_ENTRY_INC);
+  sleep_ms(SLEEP_TIME_MS);
+  hide_cursor();
+  display_on();
 
   uint8_t cmd = LCD_FUNCTION;
   num_rows > 1 ? cmd |= LCD_FUNCTION_2LINES : cmd = cmd;
@@ -26,45 +25,72 @@ I2CLCD::I2CLCD(uint8_t num_rows, uint8_t num_cols) : LCD(num_rows, num_cols)
 void I2CLCD::write_nibble(uint8_t nibble) {
   uint8_t byte = ((nibble >> 4) & 0x0f) << SHIFT_DATA;
   uint8_t b_mask = byte | MASK_E;
+#if defined (LCD_PRINT_DEBUG)
   printf("writing nibble: 0x%X to 0x%X\n", byte, b_mask);
+#endif
   sleep_ms(SLEEP_TIME_MS);
-  i2c.reg_write_uint8(LCD_I2C_ADDRESS, b_mask, byte);
+  i2c.write_blocking(LCD_I2C_ADDRESS, &b_mask, 1, false);
+  sleep_ms(SLEEP_TIME_MS);
+  i2c.write_blocking(LCD_I2C_ADDRESS, &byte, 1, false);
+  
   return;
 }
 
 void I2CLCD::write_command(uint8_t cmd) {
   uint8_t b = ((is_backlight << SHIFT_BACKLIGHT) | (((cmd >> 4) & 0x0f) << SHIFT_DATA));
   uint8_t b_mask = b | MASK_E;
+
+#if defined (LCD_PRINT_DEBUG)
   printf("writing command: 0x%X to 0x%X\n", b, b_mask);
+#endif
+
   sleep_ms(SLEEP_TIME_MS);
-  i2c.reg_write_uint8(LCD_I2C_ADDRESS, b_mask, b);
+  i2c.write_blocking(LCD_I2C_ADDRESS, &b_mask, 1, false);
+  sleep_ms(SLEEP_TIME_MS);
+  i2c.write_blocking(LCD_I2C_ADDRESS, &b, 1, false);
 
   b = ((is_backlight << SHIFT_BACKLIGHT) | ((cmd & 0x0f) << SHIFT_DATA));
   b_mask = b | MASK_E;
+
+#if defined (LCD_PRINT_DEBUG)
   printf("writing command: 0x%X to 0x%X\n", b, b_mask);
+#endif
+
   sleep_ms(SLEEP_TIME_MS);
-  i2c.reg_write_uint8(LCD_I2C_ADDRESS, b_mask, b);
+  i2c.write_blocking(LCD_I2C_ADDRESS, &b_mask, 1, false);
+  sleep_ms(SLEEP_TIME_MS);
+  i2c.write_blocking(LCD_I2C_ADDRESS, &b, 1, false);
 
   //The home and clear commands require a worst case delay of 4.1 milliseconds.
   if (cmd <= 3) {
     sleep_ms(SLEEP_TIME_MS);
-    /*uint32_t wait = millis();*/
-    /*while (millis() - wait < 5);*/
   }
+  return;
 }
 
 void I2CLCD::write_data(uint8_t data) {
   uint8_t b = (MASK_RS | (is_backlight << SHIFT_BACKLIGHT) | (((data >> 4) & 0x0f) << SHIFT_DATA));
   uint8_t b_mask = b | MASK_E;
+
+#if defined (LCD_PRINT_DEBUG)
   printf("writing data: 0x%X to 0x%X\n", b, b_mask);
+#endif
+
+  i2c.write_blocking(LCD_I2C_ADDRESS, &b_mask, 1, false);
   sleep_ms(SLEEP_TIME_MS);
-  i2c.reg_write_uint8(LCD_I2C_ADDRESS, b_mask, b);
+  i2c.write_blocking(LCD_I2C_ADDRESS, &b, 1, false);
+  sleep_ms(SLEEP_TIME_MS);
 
   b = (MASK_RS | (is_backlight << SHIFT_BACKLIGHT) | ((data & 0x0f) << SHIFT_DATA));
   b_mask = b | MASK_E;
+
+#if defined (LCD_PRINT_DEBUG)
   printf("writing data: 0x%X to 0x%X\n", b, b_mask);
+#endif
+
+  i2c.write_blocking(LCD_I2C_ADDRESS, &b_mask, 1, false);
   sleep_ms(SLEEP_TIME_MS);
-  i2c.reg_write_uint8(LCD_I2C_ADDRESS, b_mask, b);
+  i2c.write_blocking(LCD_I2C_ADDRESS, &b, 1, false);
   return;
 }
 

--- a/lcd/i2c_lcd/i2c_lcd.hpp
+++ b/lcd/i2c_lcd/i2c_lcd.hpp
@@ -17,12 +17,10 @@ public:
   I2CLCD(uint8_t num_rows, uint8_t num_cols);
   ~I2CLCD() {}
 
+  /* Derived methods */
   void write_command(uint8_t cmd);
-
   void write_data(uint8_t data);
-
   void write_nibble(uint8_t nibble);
-
   void backlight(bool on);
 
 private:
@@ -30,9 +28,9 @@ private:
   bool is_backlight;
 
 public:
-  uint8_t num_rows;
-  uint8_t num_cols;
-  uint8_t cursor_x;
-  uint8_t cursor_y;
-  bool nl_reached; //used to determine wraparound point.
+  /*uint8_t num_rows;*/
+  /*uint8_t num_cols;*/
+  /*uint8_t cursor_x;*/
+  /*uint8_t cursor_y;*/
+  /*bool nl_reached; //used to determine wraparound point.*/
 };

--- a/lcd/i2c_lcd/i2c_lcd.hpp
+++ b/lcd/i2c_lcd/i2c_lcd.hpp
@@ -4,15 +4,17 @@
 // PCF8574 pin definitions
 #define MASK_RS  (0x01)  // P0
 #define MASK_RW  (0x02)  // P1
-#define MASK_E  (0x04)  // P2
+#define MASK_E   (0x04)  // P2
 
 #define SHIFT_BACKLIGHT  (3)  // P3
-#define SHIFT_DATA  (4)  // P4-P7
+#define SHIFT_DATA       (4)  // P4-P7
+
+#define LCD_I2C_ADDRESS (0x27)
 
 class I2CLCD : public LCD {
 
 public:
-  I2CLCD(I2C* i2c, uint8_t addr, uint8_t num_rows, uint8_t num_cols);
+  I2CLCD(uint8_t num_rows, uint8_t num_cols);
   ~I2CLCD() {}
 
   void write_command(uint8_t cmd);
@@ -24,8 +26,7 @@ public:
   void backlight(bool on);
 
 private:
-  I2C* i2c;
-  uint8_t addr;
+  I2C i2c;
   bool is_backlight;
 
 public:
@@ -34,6 +35,4 @@ public:
   uint8_t cursor_x;
   uint8_t cursor_y;
   bool nl_reached; //used to determine wraparound point.
-  
-
 };

--- a/lcd/i2c_lcd/i2c_lcd.hpp
+++ b/lcd/i2c_lcd/i2c_lcd.hpp
@@ -1,0 +1,39 @@
+#include "../../i2c/i2c.hpp"
+#include "../lcd_api.hpp"
+
+// PCF8574 pin definitions
+#define MASK_RS  (0x01)  // P0
+#define MASK_RW  (0x02)  // P1
+#define MASK_E  (0x04)  // P2
+
+#define SHIFT_BACKLIGHT  (3)  // P3
+#define SHIFT_DATA  (4)  // P4-P7
+
+class I2CLCD : public LCD {
+
+public:
+  I2CLCD(I2C* i2c, uint8_t addr, uint8_t num_rows, uint8_t num_cols);
+  ~I2CLCD() {}
+
+  void write_command(uint8_t cmd);
+
+  void write_data(uint8_t data);
+
+  void write_nibble(uint8_t nibble);
+
+  void backlight(bool on);
+
+private:
+  I2C* i2c;
+  uint8_t addr;
+  bool is_backlight;
+
+public:
+  uint8_t num_rows;
+  uint8_t num_cols;
+  uint8_t cursor_x;
+  uint8_t cursor_y;
+  bool nl_reached; //used to determine wraparound point.
+  
+
+};

--- a/lcd/lcd_api.hpp
+++ b/lcd/lcd_api.hpp
@@ -8,6 +8,19 @@
 class LCD {
 
 public:
+
+  LCD(uint8_t row_cnt, uint8_t col_cnt) : 
+    num_rows(row_cnt), num_cols(col_cnt), 
+    cursor_x(0), cursor_y(0), 
+    nl_reached(false) 
+  {
+    display_off();
+    backlight(true);
+    clear();
+    write_command(LCD_ENTRY_MODE | LCD_ENTRY_INC);
+    hide_cursor();
+    display_on();
+  }
   virtual ~LCD() {}
 
   /**
@@ -16,7 +29,7 @@ public:
    *
    * @param cmd 
    */
-  virtual void write_command(uint8_t cmd) = 0;
+  virtual void write_command(uint8_t cmd) {return;}
   /**
    * @brief Write data, such as character strings, to the LCD. Child classes
    * must implement this method.
@@ -26,6 +39,7 @@ public:
   virtual void write_data(uint8_t data) = 0;
 
   virtual void clear() { 
+    printf("clearing display\n");
     write_command(LCD_CLR);
     write_command(LCD_HOME);
     cursor_x = 0;
@@ -34,31 +48,37 @@ public:
   }
 
   virtual void show_cursor() {
+    printf("showing cursor\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY | LCD_ON_CURSOR);
     return;
   }
 
   virtual void hide_cursor() { 
+    printf("hiding cursor\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY);
     return;
   }
 
   virtual void blink_cursor_on() {
+    printf("blink cursor on\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY | LCD_ON_CURSOR | LCD_ON_BLINK);
     return;
   }
 
   virtual void blink_cursor_off() {
+    printf("blink cursor off\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY | LCD_ON_CURSOR);
     return;
   }
 
   virtual void display_on() {
+    printf("turning display on\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY);
     return;
   }
 
   virtual void display_off() {
+    printf("turning display off\n");
     write_command(LCD_ON_CTRL);
     return;
   }
@@ -87,6 +107,7 @@ public:
   }
 
   virtual void put_char(uint8_t c) {
+    printf("put char %c\n", c);
 
     if (c == '\n') {
       nl_reached ? nl_reached = false : cursor_x = num_cols;

--- a/lcd/lcd_api.hpp
+++ b/lcd/lcd_api.hpp
@@ -4,23 +4,17 @@
  */
 
 #include "HD44780.h"
+#include <cstring>
 
 class LCD {
 
 public:
 
-  LCD(uint8_t row_cnt, uint8_t col_cnt) : 
-    num_rows(row_cnt), num_cols(col_cnt), 
+  LCD(uint8_t num_lines, uint8_t num_cols) : 
+    num_lines(num_lines), num_cols(num_cols), 
     cursor_x(0), cursor_y(0), 
     nl_reached(false) 
-  {
-    display_off();
-    backlight(true);
-    clear();
-    write_command(LCD_ENTRY_MODE | LCD_ENTRY_INC);
-    hide_cursor();
-    display_on();
-  }
+  {}
   virtual ~LCD() {}
 
   /**
@@ -29,7 +23,7 @@ public:
    *
    * @param cmd 
    */
-  virtual void write_command(uint8_t cmd) {return;}
+  virtual void write_command(uint8_t cmd) = 0;
   /**
    * @brief Write data, such as character strings, to the LCD. Child classes
    * must implement this method.
@@ -39,7 +33,6 @@ public:
   virtual void write_data(uint8_t data) = 0;
 
   virtual void clear() { 
-    printf("clearing display\n");
     write_command(LCD_CLR);
     write_command(LCD_HOME);
     cursor_x = 0;
@@ -48,37 +41,31 @@ public:
   }
 
   virtual void show_cursor() {
-    printf("showing cursor\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY | LCD_ON_CURSOR);
     return;
   }
 
   virtual void hide_cursor() { 
-    printf("hiding cursor\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY);
     return;
   }
 
   virtual void blink_cursor_on() {
-    printf("blink cursor on\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY | LCD_ON_CURSOR | LCD_ON_BLINK);
     return;
   }
 
   virtual void blink_cursor_off() {
-    printf("blink cursor off\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY | LCD_ON_CURSOR);
     return;
   }
 
   virtual void display_on() {
-    printf("turning display on\n");
     write_command(LCD_ON_CTRL | LCD_ON_DISPLAY);
     return;
   }
 
   virtual void display_off() {
-    printf("turning display off\n");
     write_command(LCD_ON_CTRL);
     return;
   }
@@ -106,17 +93,16 @@ public:
     return;
   }
 
-  virtual void put_char(uint8_t c) {
-    printf("put char %c\n", c);
-
+  virtual void put_char(char c) {
     if (c == '\n') {
       nl_reached ? nl_reached = false : cursor_x = num_cols;
     } else {
-      write_data(c);
-      cursor_x = (cursor_x + 1) % num_cols;
-      if (cursor_x == 0) {
-        nl_reached = true;
-        cursor_y = (cursor_y + 1) % num_rows;
+      write_data((int)c);
+      cursor_x++;
+      if (cursor_x >= num_cols) {
+        cursor_x = 0;
+        cursor_y = (cursor_y + 1) % num_lines;
+        nl_reached = (c != '\n');
       }
       move_cursor_to(cursor_x, cursor_y);
     }
@@ -126,12 +112,11 @@ public:
    * @brief Writes str to the LCD at the current cursor position, advancing as needed.
    * WARN: This method does NOT perform buffer length checks.
    *
-   * @param str 
+   * @param str c-style char array
    */
-  virtual void put_str(uint8_t* str) {
-    while (str != nullptr) {
-      put_char(*str);
-      str++;
+  virtual void put_str(char* str) {
+    for (int i = 0; i < strlen(str); ++i) {
+      put_char(str[i]);
     }
   }
 
@@ -141,7 +126,7 @@ public:
     asm volatile ("nop \n nop \n nop \n"); //small delay before writing data
 
     if (sizeof(char_map) < 8) {
-      unsigned char err[] = "Error displaying custom char\n";
+      char err[] = "Error displaying custom char\n";
       put_str(err);
       return;
     }
@@ -153,7 +138,7 @@ public:
     move_cursor_to(cursor_x, cursor_y);
   }
 
-  uint8_t num_rows;
+  uint8_t num_lines;
   uint8_t num_cols;
   uint8_t cursor_x;
   uint8_t cursor_y;

--- a/lcd/lcd_api.hpp
+++ b/lcd/lcd_api.hpp
@@ -1,0 +1,141 @@
+/**
+ * @file
+ * @brief 
+ */
+
+#include "HD44780.h"
+
+class LCD {
+
+public:
+  virtual ~LCD() {}
+
+  /**
+   * @brief Writes a command to the LCD. Child classes must implement this
+   * method. Commands are single bytes.
+   *
+   * @param cmd 
+   */
+  virtual void write_command(uint8_t cmd) = 0;
+  /**
+   * @brief Write data, such as character strings, to the LCD. Child classes
+   * must implement this method.
+   *
+   * @param data
+   */
+  virtual void write_data(uint8_t data) = 0;
+
+  virtual void clear() { 
+    write_command(LCD_CLR);
+    write_command(LCD_HOME);
+    cursor_x = 0;
+    cursor_y = 0;
+    return;
+  }
+
+  virtual void show_cursor() {
+    write_command(LCD_ON_CTRL | LCD_ON_DISPLAY | LCD_ON_CURSOR);
+    return;
+  }
+
+  virtual void hide_cursor() { 
+    write_command(LCD_ON_CTRL | LCD_ON_DISPLAY);
+    return;
+  }
+
+  virtual void blink_cursor_on() {
+    write_command(LCD_ON_CTRL | LCD_ON_DISPLAY | LCD_ON_CURSOR | LCD_ON_BLINK);
+    return;
+  }
+
+  virtual void blink_cursor_off() {
+    write_command(LCD_ON_CTRL | LCD_ON_DISPLAY | LCD_ON_CURSOR);
+    return;
+  }
+
+  virtual void display_on() {
+    write_command(LCD_ON_CTRL | LCD_ON_DISPLAY);
+    return;
+  }
+
+  virtual void display_off() {
+    write_command(LCD_ON_CTRL);
+    return;
+  }
+
+  /**
+   * @brief Some LCD modules have backlight controls. Child classes may
+   * implement this functionality if desired.
+   *
+   * @param on true for on, false for off.
+   */
+  virtual void backlight(bool on) { return; }
+
+  virtual void move_cursor_to(uint8_t x_pos, uint8_t y_pos) {
+    cursor_x = x_pos;
+    cursor_y = y_pos;
+    uint8_t position = cursor_x & 0x3f;
+
+    if (cursor_y & 1) {
+      position += 0x40;
+    }
+    if (cursor_y & 2) {
+      position += num_cols;
+    }
+    write_command(LCD_DDRAM | position);
+    return;
+  }
+
+  virtual void put_char(uint8_t c) {
+
+    if (c == '\n') {
+      nl_reached ? nl_reached = false : cursor_x = num_cols;
+    } else {
+      write_data(c);
+      cursor_x = (cursor_x + 1) % num_cols;
+      if (cursor_x == 0) {
+        nl_reached = true;
+        cursor_y = (cursor_y + 1) % num_rows;
+      }
+      move_cursor_to(cursor_x, cursor_y);
+    }
+  }
+
+  /**
+   * @brief Writes str to the LCD at the current cursor position, advancing as needed.
+   * WARN: This method does NOT perform buffer length checks.
+   *
+   * @param str 
+   */
+  virtual void put_str(uint8_t* str) {
+    while (str != nullptr) {
+      put_char(*str);
+      str++;
+    }
+  }
+
+  virtual void put_custom_char(uint8_t location, uint8_t* char_map) {
+    location &= 0x07;
+    write_command(LCD_CGRAM | (location << 3));
+    asm volatile ("nop \n nop \n nop \n"); //small delay before writing data
+
+    if (sizeof(char_map) < 8) {
+      unsigned char err[] = "Error displaying custom char\n";
+      put_str(err);
+      return;
+    }
+    
+    for (int i = 0; i < 8; ++i) {
+      write_data(char_map[i]);
+      asm volatile ("nop \n nop \n nop \n"); //small delay before writing data
+    }
+    move_cursor_to(cursor_x, cursor_y);
+  }
+
+  uint8_t num_rows;
+  uint8_t num_cols;
+  uint8_t cursor_x;
+  uint8_t cursor_y;
+  bool nl_reached; //used to determine wraparound point.
+
+};

--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,6 @@
 #include "pico/stdlib.h"
 #include "ush/picoshell.h"
 #include "lcd/i2c_lcd/i2c_lcd.hpp"
-#include "i2c/i2c.hpp"
 
 char str[] = "hello world!\n";
 
@@ -18,10 +17,11 @@ void setup(void);
 
 int main() {
   setup();
-  sleep_ms(500);
-  I2CLCD lcd = I2CLCD(20, 4);
-  sleep_ms(500);
+  I2CLCD lcd = I2CLCD(4, 20);
+  lcd.put_str(str);
 
+  lcd.show_cursor();
+  lcd.blink_cursor_on();
 
   while (1) {
     picoshell_service();

--- a/main.cpp
+++ b/main.cpp
@@ -8,7 +8,12 @@
 
 #include "pico/stdlib.h"
 #include "ush/picoshell.h"
+#include "lcd/i2c_lcd/i2c_lcd.hpp"
+#include "i2c/i2c.hpp"
 
+I2C i2c = I2C(4, 5);
+I2CLCD lcd = I2CLCD(&i2c, 0x27, 20, 4);
+char str[] = "hello world!\n";
 
 /*Function Prototypes */
 void setup(void);
@@ -17,7 +22,7 @@ int main() {
   setup();
 
   while (1) {
-    picoshell_service();
+    /*picoshell_service();*/
   }
 
   return 0;
@@ -33,6 +38,8 @@ void setup(void) {
   gpio_set_dir(PICO_DEFAULT_LED_PIN, true);
   gpio_put(PICO_DEFAULT_LED_PIN, 1);
 
-  picoshell_init();
+  lcd.put_str((uint8_t *)str);
+
+  /*picoshell_init();*/
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -11,8 +11,6 @@
 #include "lcd/i2c_lcd/i2c_lcd.hpp"
 #include "i2c/i2c.hpp"
 
-I2C i2c = I2C(4, 5);
-I2CLCD lcd = I2CLCD(&i2c, 0x27, 20, 4);
 char str[] = "hello world!\n";
 
 /*Function Prototypes */
@@ -20,9 +18,13 @@ void setup(void);
 
 int main() {
   setup();
+  sleep_ms(500);
+  I2CLCD lcd = I2CLCD(20, 4);
+  sleep_ms(500);
+
 
   while (1) {
-    /*picoshell_service();*/
+    picoshell_service();
   }
 
   return 0;
@@ -38,8 +40,6 @@ void setup(void) {
   gpio_set_dir(PICO_DEFAULT_LED_PIN, true);
   gpio_put(PICO_DEFAULT_LED_PIN, 1);
 
-  lcd.put_str((uint8_t *)str);
-
-  /*picoshell_init();*/
+  picoshell_init();
 }
 

--- a/ush/node_i2c.cpp
+++ b/ush/node_i2c.cpp
@@ -42,29 +42,29 @@ static void i2c_init_exec_callback(struct ush_object *self,
   }
   uint sda = atoi(argv[1]);
   if (sda >= 26 || sda < 0) {
-    ush_print(self, "ERROR: Invalid SDA pin");
+    ush_print(self, (char*)"ERROR: Invalid SDA pin");
     return;
   }
 
   uint scl = atoi(argv[2]);
   if (scl >= 27 || scl < 1) {
-    ush_print(self, "ERROR: Invalid SCL pin");
+    ush_print(self, (char*)"ERROR: Invalid SCL pin");
     return;
   }
 
   i2c_inst_t* i2c = pin_to_inst(sda);
   if (i2c == NULL) {
-    ush_print(self, "ERROR: Could not find I2C instance.");
+    ush_print(self, (char*)"ERROR: Could not find I2C instance.");
     return;
   }
 
   uint i2c_port = i2c_get_index(i2c);
 
   if (i2c_port == 0 && i2c0_is_init) {
-    ush_print(self, "I2C0 port already initialized.\r\n");
+    ush_print(self, (char*)"I2C0 port already initialized.\r\n");
   } 
   else if (i2c_port == 1 && i2c1_is_init) {
-    ush_print(self, "I2C1 port already initialized.\r\n");
+    ush_print(self, (char*)"I2C1 port already initialized.\r\n");
   }
   else {
     i2c_init(i2c, 400 * 1000); //defaults to 400KHz baudrate
@@ -91,18 +91,18 @@ static void i2c_deinit_exec_callback(struct ush_object *self,
   port_num >= 1 ? port_num = 1 : port_num = 0;
 
   if (!i2c0_is_init && port_num == 0) {
-    ush_print(self, "ERROR: I2C port 0 must be initialized before deinitializing.\r\n");
+    ush_print(self, (char*)"ERROR: I2C port 0 must be initialized before deinitializing.\r\n");
     return;
   }
 
   if (!i2c1_is_init && port_num == 1) {
-    ush_print(self, "ERROR: I2C port 1 must be initialized before deinitializing.\r\n");
+    ush_print(self, (char*)"ERROR: I2C port 1 must be initialized before deinitializing.\r\n");
     return;
   }
 
   i2c_inst_t* i2c = i2c_get_instance(port_num);
   if (i2c == NULL) {
-    ush_print(self, "ERROR: Could not find I2C instance.");
+    ush_print(self, (char*)"ERROR: Could not find I2C instance.");
     return;
   }
 
@@ -144,12 +144,12 @@ static void i2c_scan_exec_callback(struct ush_object *self,
 
   i2c_inst_t* i2c = i2c_get_instance(port);
   if (i2c == NULL) {
-    ush_print(self, "ERROR: Could not find I2C instance.");
+    ush_print(self, (char*)"ERROR: Could not find I2C instance.");
     return;
   }
 
   if ((port == 0 && !i2c0_is_init) || (port == 1 && !i2c1_is_init)) {
-    ush_print(self, "ERROR: I2C port must be initialized before scanning.\r\n");
+    ush_print(self, (char*)"ERROR: I2C port must be initialized before scanning.\r\n");
     return;
   }
 
@@ -191,12 +191,12 @@ static void i2c_write_exec_callback(struct ush_object *self,
 
   i2c_inst_t* i2c = i2c_get_instance(port);
   if (i2c == NULL) {
-    ush_print(self, "ERROR: Could not find I2C instance.");
+    ush_print(self, (char*)"ERROR: Could not find I2C instance.");
     return;
   }
 
   if ((port == 0 && !i2c0_is_init) || (port == 1 && !i2c1_is_init)) {
-    ush_print(self, "ERROR: I2C port must be initialized before scanning.\r\n");
+    ush_print(self, (char*)"ERROR: I2C port must be initialized before scanning.\r\n");
     return;
   }
 

--- a/ush/picoshell.cpp
+++ b/ush/picoshell.cpp
@@ -7,6 +7,7 @@
 
 static char ush_in_buf[BUF_IN_SIZE];
 static char ush_out_buf[BUF_OUT_SIZE];
+static char hostname[] = "Pico2"; //Change to your platform of choice
 
 // Picoshell instance handler
 struct ush_object ush;
@@ -40,7 +41,7 @@ static const struct ush_descriptor ush_desc = {
     .output_buffer = ush_out_buf,               // working output buffer
     .output_buffer_size = sizeof(ush_out_buf),  // working output buffer size
     .path_max_length = PATH_MAX_SIZE,           // path maximum length (stack)
-    .hostname = "Pico2",                        // hostname (in prompt)
+    .hostname = hostname,                        // hostname (in prompt)
 };
 
 extern void picoshell_cmds_add(void);

--- a/ush/ush_const.h
+++ b/ush/ush_const.h
@@ -30,9 +30,9 @@ extern "C" {
 #endif
 
 /** Library name used in welcome message. */
-#define USH_NAME "uShell"
+#define USH_NAME "Picoshell"
 /** Library version used to identification purposes. */
-#define USH_VERSION "0.1.0"
+#define USH_VERSION "0.1.1"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
After a couple of days of work, I managed to get my 4x20 ~~blazeit~~ display working!
![hello_world_i2c_display](https://github.com/user-attachments/assets/73c716e0-c4b4-4cf9-9120-1e8c88ad3856)

The `LCD` class acts as a HAL for various HD44780-based LCDs. Child classes are responsible for implementing how data is sent to the display. The API is similar to that found in the `LiquidCrystal` Arduino library. 